### PR TITLE
Replace PopupContentProps by PopupProps

### DIFF
--- a/src/content/docs/react/custom-popups.mdx
+++ b/src/content/docs/react/custom-popups.mdx
@@ -38,7 +38,7 @@ component:
           </ImageAnnotator>
     
           <ImageAnnotationPopup
-            popup={(props: PopupContentProps) => (
+            popup={(props: PopupProps) => (
               <div>
                 Hello World
               </div>
@@ -102,7 +102,7 @@ import {
   AnnotationBody
 } from '@annotorious/react';
 
-const CommentPopup = (props: PopupContentProps) => {
+const CommentPopup = (props: PopupProps) => {
 
   const { annotation, onCreateBody, onUpdateBody } = props;
 
@@ -146,7 +146,7 @@ export default function App() {
         <img src="example.jpg" />
       </ImageAnnotator>
 
-      <ImageAnnotationPopup popup={(props: PopupContentProps) => (
+      <ImageAnnotationPopup popup={(props: PopupProps) => (
         <CommentPopup {...props} />
       )} />
     </Annotorious>
@@ -184,7 +184,7 @@ export default function App() {
         }} />
 
         <OpenSeadragonAnnotationPopup
-          popup={(props: PopupContentProps) => (
+          popup={(props: PopupProps) => (
             <div>
               Hello World
             </div>


### PR DESCRIPTION
The popup documentation is using `PopupContentProps`, but the correct one is PopupProps.